### PR TITLE
Add the "build.rollupOptions.input" to explicitly point to the index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Promo Dados EsmiÓptica</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./src/main.jsx"></script>
+    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,5 @@
 import { defineConfig, loadEnv } from 'vite'
+
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
@@ -7,6 +8,13 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   return {
   base: '/esmioptica-dados/',
+  build: {
+    rollupOptions: {
+      input: {
+        main: 'index.html',
+      },
+    },
+  },
   server: {
     host: true,
     port: 5173,


### PR DESCRIPTION
Fix: add the "build.rollupOptions.input" to explicitly point to the "index.html" file and fix the github page build.
Fix: the script and icon paths are restored to be absolute (e.g., /src/main.jsx). This is the standard way for Vite to identify the entry points.